### PR TITLE
fix package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "search-linogh",
+  "name": "search-linough",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "search-linogh",
+      "name": "search-linough",
       "dependencies": {
         "@react-router/fs-routes": "^7.4.1",
         "@react-router/node": "^7.4.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "search-linogh",
+  "name": "search-linough",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- correct package name to "search-linough" in package.json and package-lock.json

## Testing
- `npm install` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be31589bc48323b6f839a051cf81c1