### PR TITLE
Await fetchStores in search loader

### DIFF
--- a/app/lib/supabase/db.ts
+++ b/app/lib/supabase/db.ts
@@ -14,7 +14,7 @@ import { supabase } from "./client"
  * @see {@link https://supabase.com/docs/guides/database} for more information on Supabase database operations.
  * @see {@link https://supabase.com/docs/guides/api} for more information on Supabase API operations.
  */
-export const fetchStores = async () => {
+export const fetchStores = async (): Promise<Store[]> => {
   const { data, error } = await supabase
     .from("stores")
     .select("*")

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -11,7 +11,7 @@ export function meta({}: Route.MetaArgs) {
 }
 
 export const loader = async () => {
-  return { stores: fetchStores() };
+  return { stores: await fetchStores() };
 };
 
 export async function action({ request }: { request: Request }) {


### PR DESCRIPTION
## Summary
- await `fetchStores` in search page loader to return store list immediately
- type `fetchStores` to return `Promise<Store[]>`

## Testing
- `npm run build` *(fails: react-router not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be315871b483239844e14ba7feeb7d