### PR TITLE
docs: fix Docker run port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To build and run using Docker:
 docker build -t my-app .
 
 # Run the container
-docker run -p 3000:3000 my-app
+docker run -p 3000:8080 my-app
 ```
 
 The containerized application can be deployed to any platform that supports Docker, including:


### PR DESCRIPTION
## Summary
- fix Docker run example to map host port 3000 to container port 8080

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be31596d6483238c9032e897bd3394