### PR TITLE
test: add utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "react-router build",
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.7",
@@ -38,6 +39,7 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.2",
     "vite": "^5.4.11",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^1.6.0"
   }
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAddress, calcMatchScore, findBestMatch } from '../app/utils';
+
+describe('normalizeAddress', () => {
+  it('replaces Japanese address parts with hyphens', () => {
+    expect(normalizeAddress('1丁目2番地3号')).toBe('1-2-3');
+  });
+
+  it('removes spaces, fullwidth numbers, and room numbers', () => {
+    expect(normalizeAddress(' １丁目 ２番地３号 １０１号室')).toBe('1-2-3');
+  });
+});
+
+describe('calcMatchScore', () => {
+  it('returns 100 for identical addresses', () => {
+    expect(calcMatchScore('1丁目2番地3号', '1丁目2番地3号')).toBe(100);
+  });
+
+  it('returns a partial score for near matches', () => {
+    expect(calcMatchScore('1丁目2番地3号', '1丁目2番地4号')).toBe(80);
+  });
+
+  it('returns 0 for completely different addresses', () => {
+    expect(calcMatchScore('', '1丁目2番地3号')).toBe(0);
+  });
+});
+
+describe('findBestMatch', () => {
+  it('returns 100 when search term matches address', () => {
+    expect(findBestMatch('1丁目2番地3号', '1丁目2番地3号', 'サンプルマンション')).toBe(100);
+  });
+
+  it('returns 100 when search term matches full address including apartment', () => {
+    expect(findBestMatch('1丁目2番地3号サンプルマンション', '1丁目2番地3号', 'サンプルマンション')).toBe(100);
+  });
+
+  it('returns 0 when search term is empty', () => {
+    expect(findBestMatch('', '1丁目2番地3号', 'サンプルマンション')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for normalizeAddress, calcMatchScore, and findBestMatch
- add npm test script using vitest

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be3159bcf48323b4c97e49b442915b