### PR TITLE
Fix Supabase env vars

### DIFF
--- a/app/lib/supabase/client.ts
+++ b/app/lib/supabase/client.ts
@@ -1,8 +1,11 @@
 import { createClient } from '@supabase/supabase-js'
 import { type Database } from '~/database.types'
 
+// Vite exposes environment variables that need to be prefixed with `VITE_`
+// when they are accessed on the client. Using `process.env` here causes the
+// values to be undefined in the browser.
 export const supabase = createClient<Database>(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_KEY!
+  import.meta.env.VITE_SUPABASE_URL!,
+  import.meta.env.VITE_SUPABASE_KEY!
 )
 


### PR DESCRIPTION
## Summary
- fix environment variable names for Supabase client

## Testing
- `npm run typecheck` *(fails: react-router not found)*

------
https://chatgpt.com/codex/tasks/task_b_682bdf0c7c9083239f81c0f78e9b11cc