### PR TITLE
Integrate supabase for admin features

### DIFF
--- a/app/routes/admin.panel.addHouse.tsx
+++ b/app/routes/admin.panel.addHouse.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Home, X } from "lucide-react";
 import { AddFormPanel, commonAddFormLoader } from "~/components/AddFormPanel";
-import type { House, NewHouse, Store } from "~/types";
+import type { NewHouse, Store } from "~/types";
 import {
   redirect,
   useLoaderData,
@@ -44,7 +44,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   try {
-    // await insertHouse(houses);
+    await insertHouse(houses);
     return redirect("/admin/panel/addHouse?success=1");
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Summary
- wire add-house route to Supabase insert API
- connect store edit page to Supabase for fetching, updating and deleting stores

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run typecheck` *(fails: react-router: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be3508850c8323805d12f99ad6d272